### PR TITLE
fix: 🐛 crash when loading DotLottieView a second time

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -21,8 +21,8 @@ jobs:
               "source_repo": "${{ github.repository }}",
               "source_package": "",
               "release_tag": "${{ github.event.release.tag_name }}",
-              "release_name": "${{ github.event.release.name }}",
-              "release_body": "${{ github.event.release.body }}",
+              "release_name": ${{ toJSON(github.event.release.name) }},
+              "release_body": ${{ toJSON(github.event.release.body) }},
               "release_url": "${{ github.event.release.html_url }}",
               "sender": "${{ github.actor }}"
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* fix: crash when loading DotLottieView a second time for android
+
 ## 0.0.3
 
 * chore: upgraded dependancies for web, android and ios. Added opengl support for android.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
     dependencies {
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
-        implementation("com.github.LottieFiles:dotlottie-android:0.13.5")
+        implementation("com.github.LottieFiles:dotlottie-android:0.13.6")
     }
 
     testOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dotlottie_flutter
 description: "dotLottie for Flutter."
-version: 0.0.3
+version: 0.0.4
 homepage: "https://lottiefiles.com"
 repository: "https://github.com/lottiefiles/dotlottie-flutter"
 


### PR DESCRIPTION
Fixes: https://github.com/LottieFiles/dotlottie-flutter/issues/8
Bumped android version to 0.13.6