### PR TITLE
Cap dotlottie-ios SPM dependency to <0.16.0 to match podspec (fixes broken 0.16.x under SPM)

### DIFF
--- a/ios/dotlottie_flutter/Package.swift
+++ b/ios/dotlottie_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "dotlottie-flutter", targets: ["dotlottie_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/LottieFiles/dotlottie-ios.git", from: "0.15.7"),
+        .package(url: "https://github.com/LottieFiles/dotlottie-ios.git", "0.15.7"..<"0.16.0"),
         .package(name: "FlutterFramework", path: "../FlutterFramework")
     ],
     targets: [

--- a/macos/dotlottie_flutter/Package.swift
+++ b/macos/dotlottie_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "dotlottie-flutter", targets: ["dotlottie_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/LottieFiles/dotlottie-ios.git", from: "0.15.7"),
+        .package(url: "https://github.com/LottieFiles/dotlottie-ios.git", "0.15.7"..<"0.16.0"),
         .package(name: "FlutterFramework", path: "../FlutterFramework")
     ],
     targets: [


### PR DESCRIPTION
## What

Cap the **SPM** `dotlottie-ios` dependency to `"0.15.7"..<"0.16.0"` in both `ios/dotlottie_flutter/Package.swift` and `macos/dotlottie_flutter/Package.swift`, matching what the podspecs already declare with `~> 0.15.7`.

## Why

The plugin constrains its native dependency two different ways, and they disagree:

| Manifest | Constraint | Effective range |
|---|---|---|
| `ios/macos` podspec | `~> 0.15.7` | `>= 0.15.7, < 0.16.0` |
| `ios/macos` `Package.swift` | `from: "0.15.7"` | `>= 0.15.7, < 1.0.0` |

So **SPM consumers silently resolve up to 0.16.x**, while CocoaPods consumers stay on 0.15.x. 0.16.0 introduced the wgpu (`WgpuNative`) rendering backend, which is currently broken under SPM:

- **Simulator:** the `ios-arm64_x86_64-simulator` slice of `DotLottiePlayer` carries a stray *absolute* `LC_LOAD_DYLIB` baked in on the CI runner (`/Users/runner/work/wgpu-native/.../libwgpu_native.dylib`) alongside the correct `@rpath` one. That path exists nowhere else, so dyld aborts and the app **crashes at launch** (`Namespace DYLD, Library missing`, `EXC_CRASH`/`SIGABRT`).
- **Device / release:** App Store Connect rejects the upload — see [LottieFiles/dotlottie-ios#134].

CocoaPods users are shielded by the `~>` cap; SPM users are not. Aligning the SPM constraint restores parity and stops SPM consumers from silently pulling the broken 0.16.x.

## Notes

- This is a workaround for the interim, not a fix for wgpu itself (tracked in [LottieFiles/dotlottie-ios#134]). When 0.16.x is fixed upstream, **both** the SPM range and the podspec `~>` can be bumped together in the same release.
- No functional/API change — 0.15.7 already exposes the `DotLottie` product used by the plugin.

## Testing

Verified in a Flutter app on Flutter 3.44.6 with SPM enabled: with the cap, SwiftPM resolves `dotlottie-ios` to 0.15.7, `DotLottiePlayer` links only `libc++`/`libSystem` (no wgpu load command), and the app launches cleanly on an iOS Simulator that previously SIGABRT'd at launch.
