### PR TITLE
docs: add animation-library tip and link runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # dotLottie Flutter
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
 A Flutter plugin for rendering Lottie and dotLottie animations with full playback control, state machine support, and cross-platform compatibility.
+
+> Full documentation is available at [docs.lottiefiles.com](https://docs.lottiefiles.com/en/runtimes/distributions/flutter).
 
 **Platforms supported:** iOS, Android, macOS, Web, Windows, and Linux
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,7 @@ description: "Render dotLottie and Lottie animations in Flutter. Supports playba
 version: 0.1.5
 homepage: "https://lottiefiles.com"
 repository: "https://github.com/lottiefiles/dotlottie-flutter"
+documentation: "https://docs.lottiefiles.com/en/runtimes/distributions/flutter"
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
- Adds the `[!TIP]` free-animations CTA to the README.
- Adds a documentation link and pubspec `documentation` field pointing at `https://docs.lottiefiles.com/en/runtimes/distributions/flutter`.