### PR TITLE
fix(example): removed duplicate plugin package breaking spm resolution

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
-		78DABEA22ED26510000E7860 /* dotlottie_flutter */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = dotlottie_flutter; path = ../../ios/dotlottie_flutter; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -112,7 +111,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				78DABEA22ED26510000E7860 /* dotlottie_flutter */,
 				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 		CB4C79E6D62778A5940BEE1F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		ED75D16CF03A4359A008A560 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
-		78DABEA22ED26510000E7860 /* dotlottie_flutter */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = dotlottie_flutter; path = ../../../macos/dotlottie_flutter; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,7 +181,6 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				78DABEA22ED26510000E7860 /* dotlottie_flutter */,
 				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,


### PR DESCRIPTION
Since Flutter 3.44 the SPM symlink is named after the plugin's directory basename instead of the plugin name, which for the example's path dependency no longer matches the package name, **it currently breaks SPM resolution and blocks the apple example build**.

```
 Launching lib/main.dart on macOS in debug mode...
  Error: An error occurred when adding Swift Package Manager integration:
    Error: Xcode failed to resolve Swift Package Manager dependencies:
  2026-08-11 21:14:04.228 xcodebuild[19603:6122421]  DVTDeviceOperation: Encountered a build number "" that is incompatible with DVTBuildVersion.
  2026-08-11 21:14:04.229 xcodebuild[19603:6122412] [MT] DVTDeviceOperation: Encountered a build number "" that is incompatible with DVTBuildVersion.
  2026-08-11 21:14:04.323 xcodebuild[19603:6122412] Writing error result bundle to /var/folders/dm/w7ndhmx10cxd9k9g4m2f1rjc0000gn/T/ResultBundle_2026-11-08_21-14-0004.xcresult
  xcodebuild: error: Could not resolve package dependencies:
    unable to override package 'dotlottie_flutter' because its identity 'dotlottie-flutter' doesn't match override's identity (directory name) 'dotlottie_flutter'
    binary target 'DotLottiePlayer' could not be mapped to an artifact with expected name 'DotLottiePlayer'
    multiple similar targets 'dotlottie_flutter' appear in package 'dotlottie-flutter' and 'dotlottie_flutter', this may indicate that the two packages are the same and can be de-duplicated by using mirrors. if they are not duplicate consider using the `moduleAliases` parameter in manifest to provide unique names
  3

  Swift Package Manager is currently an experimental feature, please file a bug at
    https://github.com/flutter/flutter/issues/new?template=01_activation.yml
  Consider including a copy of the following files in your bug report:
    macos/Runner.xcodeproj/project.pbxproj
    macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme (or the scheme for the flavor used)

  To add Swift Package Manager integration manually, please use the following instructions:
  https://docs.flutter.dev/to/add-swift-package-manager-manually

  You can also disable Swift Package Manager for the project by following these instructions:
    https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-turn-off-swift-package-manager
  Disabling Swift Package Manager will not be allowed in a future version of Flutter.


  Exited (1).
```