### PR TITLE
fix: honour width and height in the widget's layout

### DIFF
--- a/lib/dotlottie_flutter.dart
+++ b/lib/dotlottie_flutter.dart
@@ -261,6 +261,16 @@ class _DotLottieViewState extends State<DotLottieView> {
 
   @override
   Widget build(BuildContext context) {
+    final view = _buildPlatformView();
+    if (widget.width == null && widget.height == null) return view;
+    return SizedBox(
+      width: widget.width?.toDouble(),
+      height: widget.height?.toDouble(),
+      child: view,
+    );
+  }
+
+  Widget _buildPlatformView() {
     if (kIsWeb) {
       return _buildWebView();
     } else if (defaultTargetPlatform == TargetPlatform.android) {


### PR DESCRIPTION
DotLottieView documents width as "explicit width in logical pixels", but the value was only forwarded to the native player and never reached Flutter layout.

| Main | Fixed |
| --- | --- |
| <img width="1052" height="816" alt="image" src="https://github.com/user-attachments/assets/3045a44e-6c54-459f-9d00-d29e73ea0bc9" /> | <img width="1060" height="812" alt="image" src="https://github.com/user-attachments/assets/8d40f871-295a-4aaf-b292-285118580746" /> |
| <img width="1144" height="812" alt="image" src="https://github.com/user-attachments/assets/7cad0a06-d172-4f83-8210-fa82f72212be" /> | <img width="1136" height="800" alt="image" src="https://github.com/user-attachments/assets/c91d3019-98a2-4ea8-844f-32f10d3f72e8" /> |
| <img width="1400" height="804" alt="image" src="https://github.com/user-attachments/assets/40829f1b-4a11-4a76-a27d-90eaf011d497" /> | <img width="1376" height="808" alt="image" src="https://github.com/user-attachments/assets/4bd7ce0f-2ddf-49c9-bc21-df6f4fdcf534" /> |
| <img width="1310" height="846" alt="image" src="https://github.com/user-attachments/assets/64781835-ef10-44c2-9b3c-128525986ee1" /> | <img  alt="CleanShot 2026-08-11 at 22 34 48" src="https://github.com/user-attachments/assets/555ec39a-88a9-416c-b480-e488a5b11b50" /> |

- Previously, the explicit logical pixels aren't properly reached to Flutter layout
- Thus, a few behavior wasn't matched as documented (_The specified size ignored_)
- This also aligns the width and height contract with Flutter standard widgets(_such as Image, Container and SizedBox_), so the widget sizes the way Flutter users already expect