### PR TITLE
chore: add syntax highlighting for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Linux renderer uses the pre-built `libdotlottie_rs.so` bundled with the plug
 
 ## Quick Start
 
-```
+```dart
 import 'package:flutter/material.dart';
 import 'package:dotlottie_flutter/dotlottie_flutter.dart';
 


### PR DESCRIPTION
minor docs fixes

| Before | After |
| --- | --- |
| <img width="1374" height="1556" alt="CleanShot 2026-08-11 at 23 05 47@2x" src="https://github.com/user-attachments/assets/216f041e-842a-4f6e-a93d-d48e9d8269ee" /> | <img width="1076" height="1456" alt="CleanShot 2026-08-11 at 23 06 15@2x" src="https://github.com/user-attachments/assets/6f0a1eab-9b27-4af9-b7f8-ad3bfd971d17" /> |