### PR TITLE
chore: v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.6
+
+* fix: `DotLottieView` now honours its `width` and `height` — the platform view is
+  wrapped in a `SizedBox` when either is set, instead of expanding to the parent
+* fix(ios): opt out of `UIHostingController` safe-area insets so the animation stays
+  inside the platform view's bounds (iOS 16.4+)
+* fix(example): removed a duplicate plugin package that broke SPM resolution
+
 ## 0.1.5
 
 * chore: upgrading macos and ios deps to fix SPM error related to wgpu

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.5"
+    version: "0.1.6"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dotlottie_flutter
 description: "Render dotLottie and Lottie animations in Flutter. Supports playback control, theming and state machines on Android, iOS, macOS and Web."
-version: 0.1.5
+version: 0.1.6
 homepage: "https://lottiefiles.com"
 repository: "https://github.com/lottiefiles/dotlottie-flutter"
 documentation: "https://docs.lottiefiles.com/en/runtimes/distributions/flutter"


### PR DESCRIPTION
Release prep for `0.1.6`.

## Changes since v0.1.5

| PR | Change |
| --- | --- |
| #36 | `DotLottieView` honours `width` / `height` (wraps the platform view in a `SizedBox`) |
| #34 | iOS platform view opts out of `UIHostingController` safe-area insets |
| #35 | example: removed duplicate plugin package that broke SPM resolution |
| #37 | README: syntax highlighting for the quick-start snippet (docs only) |
| #32 | docs: animation-library tip + Flutter runtime doc links (docs only) |

## This PR

- `pubspec.yaml`: `0.1.5` → `0.1.6`
- `CHANGELOG.md`: new `## 0.1.6` block (the three user-facing fixes; docs-only changes omitted, per existing convention)
- `example/pubspec.lock`: regenerated so the recorded plugin version tracks the bump

`flutter pub publish --dry-run` passes with 0 warnings.

The iOS/macOS podspecs are deliberately left at `s.version = '0.1.4'`: it is ignored for path-resolved local plugin pods, and bumping it would also require regenerating `example/ios/Podfile.lock` and `example/macos/Podfile.lock`, which record the pod at `0.1.4`. Same as the `v0.1.5` release.

> [!NOTE]
> `flutter test` fails on `test/dotlottie_flutter_test.dart`, but this is **pre-existing** — it fails identically at `v0.1.5`. The mock extends `DotLottieFlutterPlatform` and is missing ~95 members the interface has since grown, so the file fails to compile. Not a release blocker; worth a follow-up.

After merge: tag `v0.1.6` on `main`, publish to pub.dev, then create the GitHub release (which triggers `notify-docs.yml`).