### PR TITLE
ci: publish to pub.dev automatically on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to pub.dev
+
+# Publishing is authorised by a short-lived OIDC token minted per run, not by a
+# stored secret. pub.dev only honours that token for tag-triggered runs, so this
+# workflow must stay on `push: tags` — a `workflow_dispatch` or `release` trigger
+# would fail authentication.
+#
+# Requires "Automated publishing" to be enabled on pub.dev for this repository
+# with the tag pattern below (Admin tab of the dotlottie_flutter package).
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
Publishing currently requires someone to hold pub.dev credentials locally and run `flutter pub publish` by hand. This replaces that with a tag-triggered workflow.

Push a `vX.Y.Z` tag → the package publishes. That's the whole flow.

## There is no token to create

Worth stating up front, because it changes what we ask for: pub.dev automated publishing uses **short-lived OIDC tokens minted per run**, not a stored secret. Nothing to put in repo secrets, nothing to rotate, nothing to leak.

The trigger has to stay `push: tags` — pub.dev only honours the OIDC token for tag-triggered runs, so `workflow_dispatch` and `release` would both fail auth. That constraint is commented in the file so nobody "simplifies" it later.

## One-time setup on pub.dev

pub.dev → `dotlottie_flutter` → **Admin** tab → **Automated publishing** → enable publishing from GitHub Actions:

- Repository: `LottieFiles/dotlottie-flutter`
- Tag pattern: `v{{version}}`

The package is under the `lottiefiles.com` verified publisher, so this needs an admin of that publisher.

## Why the official reusable workflow

`dart-lang/setup-dart/.github/workflows/publish.yml@v1` is what dart.dev recommends, and it matters here that it sets up the **Flutter** SDK, not just Dart — this package has `sdk: flutter` dependencies, so a plain `dart pub get` would fail version solving. The reusable workflow's inner actions are already SHA-pinned upstream. It runs a dry-run before publishing.

## Deliberately not included: automated version bumps

Considered `changesets`, but it's `@changesets/cli` — npm-ecosystem, and adopting it means a Node toolchain in a Dart repo purely to manage a CHANGELOG. The Dart-native analogue is `release-please` with `release-type: dart`, which bumps `pubspec.yaml` and updates `CHANGELOG.md` from our conventional commits (we already write `fix:` / `feat:` / `chore:`).

It's left for a follow-up because of a chaining problem worth solving on its own: **GitHub does not trigger workflow runs from events created with the default `GITHUB_TOKEN`**, so a tag pushed by release-please would not fire this workflow. Fixing that needs a PAT — reintroducing exactly the long-lived secret OIDC just removed. Open question for that follow-up: whether pub.dev will authorise a run triggered by release-please's tag at all.

Version bumps stay manual for now; everything after the tag is automated.

## This does not apply retroactively to v0.1.6

Workflows for a `push: tags` event are read from **the tagged commit's tree**, not from the default branch. `v0.1.6` points at `826c8db`, which predates this file, so that tag cannot be published by this workflow — re-pushing it would fire nothing.

`0.1.6` was therefore published manually. This pipeline takes effect from the next version tag.

(This is also why the trigger is commented as load-bearing: the workflow must exist in the commit being tagged.)