### PR TITLE
docs: update README with title and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# dotLottie Flutter
+<p align="center">
+  <img
+    src="https://lottie.host/407e5312-d8d3-41f8-a917-f0ea1c94adb2/Tm9pP2T8eL.svg"
+    alt="dotLottie Flutter"
+    width="300"
+  />
+</p>
+
+<h1 align="center">dotLottie Flutter</h1>
 
 > [!TIP]
 > Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).


### PR DESCRIPTION
Add header and image to README for dotLottie Flutter

<img width="800" height="632" alt="CleanShot 2026-08-12 at 17 58 43" src="https://github.com/user-attachments/assets/49576a6d-2c16-47eb-81da-41467982add1" />

---

I've also confirmed the animated SVG can live in pub.dev. Reference:
https://pub.dev/packages/smil_animated_svg

<img width="800" alt="CleanShot 2026-08-12 at 17 52 24@2x" src="https://github.com/user-attachments/assets/22532372-0ba6-423f-ad80-b996c17ba95d" />
