### PR TITLE
migrate to Flutter Built-in Kotlin (Android)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.1.7
+
+* chore(android): migrate to Flutter's Built-in Kotlin. The Android plugin no
+  longer applies the Kotlin Gradle Plugin (KGP) itself; Flutter's Gradle plugin
+  auto-applies KGP on the plugin subproject instead. This silences the
+  `Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP)`
+  warning that Flutter prints for consumers of `dotlottie_flutter`, and
+  prepares the plugin for AGP 9. Matches the pattern used across all current
+  `flutter/packages` plugins (video_player, camera_android_camerax,
+  shared_preferences_android, url_launcher_android, etc.).
+* **Breaking**: minimum supported Flutter is now 3.44 / Dart 3.12 (required by
+  the Built-in Kotlin migration). Consumers on older Flutter must stay on
+  `dotlottie_flutter: ^0.1.6`.
+
 ## 0.1.6
 
 * fix: `DotLottieView` now honours its `width` and `height` — the platform view is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
   prepares the plugin for AGP 9. Matches the pattern used across all current
   `flutter/packages` plugins (video_player, camera_android_camerax,
   shared_preferences_android, url_launcher_android, etc.).
-* **Breaking**: minimum supported Flutter is now 3.44 / Dart 3.12 (required by
-  the Built-in Kotlin migration). Consumers on older Flutter must stay on
-  `dotlottie_flutter: ^0.1.6`.
+* Raises the minimum supported Flutter to 3.44 / Dart 3.12, as required by the
+  Built-in Kotlin migration. No Dart API changed: pub resolves consumers on
+  older SDKs to `dotlottie_flutter: 0.1.6` automatically.
 
 ## 0.1.6
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "com.lottiefiles.dotlottie_flutter"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.1.0"
+    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.9.1")
+        classpath("com.android.tools.build:gradle:8.11.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -24,7 +24,6 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "com.lottiefiles.dotlottie_flutter"
@@ -34,10 +33,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -65,5 +60,11 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,9 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.11.1")
+        // This plugin is never applied here — Flutter's Gradle plugin
+        // auto-applies KGP on this subproject. The classpath entry is still
+        // required to resolve KGP below AGP 9. Do not remove.
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -20,6 +20,9 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.11.1" apply false
+    // Not applied here — Flutter's Gradle plugin auto-applies KGP on plugin
+    // subprojects. The pin is still required to resolve KGP below AGP 9.
+    // Do not remove.
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.6"
+    version: "0.1.7"
   fake_async:
     dependency: transitive
     description:
@@ -300,5 +300,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: "Demonstrates how to use the dotlottie_flutter plugin."
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.12.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dotlottie_flutter
 description: "Render dotLottie and Lottie animations in Flutter. Supports playback control, theming and state machines on Android, iOS, macOS and Web."
-version: 0.1.6
+version: 0.1.7
 homepage: "https://lottiefiles.com"
 repository: "https://github.com/lottiefiles/dotlottie-flutter"
 documentation: "https://docs.lottiefiles.com/en/runtimes/distributions/flutter"
 
 environment:
-  sdk: ^3.9.2
-  flutter: ">=3.3.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
  Silences the `Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): dotlottie_flutter`
  warning that fires on every consumer's Android build.

  Removes our explicit `apply plugin: "kotlin-android"`. Flutter's Gradle plugin (>=3.44) auto-applies KGP on
  plugin subprojects, so this is a runtime no-op — it just stops tripping Flutter's regex KGP-detector. Matches the
   pattern used by every current `flutter/packages` Kotlin plugin (video_player_android,
  shared_preferences_android, url_launcher_android, webview_flutter_android, path_provider_android, etc.).

  Also bumps the example's Gradle/AGP/Kotlin to Flutter's current minimums.

  ## Breaking change
  Minimum Flutter bumps to `>=3.44.0` / Dart `^3.12.0` (required by Built-in Kotlin). Consumers on older Flutter
  stay on `dotlottie_flutter: ^0.1.6`.

  ## Test plan
  - [x] `flutter build apk --debug` on AGP 8.11.1 → builds, KGP warning gone.
  - [x] Verified with a temporary example variant still applying `id("kotlin-android")` in `app/build.gradle.kts`
  (simulated un-migrated consumer) → plugin still builds cleanly.


Followed the [official Flutter guide for plugin 
  authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), and
  cross-checked against other Flutter plugins.
