### PR TITLE
chore: sync root pubspec.lock with the 3.44 SDK floor

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -230,5 +230,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"


### PR DESCRIPTION
PR #42 raised the plugin to Flutter 3.44 / Dart 3.12 and refreshed `example/pubspec.lock`, but the root `pubspec.lock` kept the old constraints:

```diff
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
```

Regenerated with `pub get` so the two lockfiles agree.

Not user-facing — pub excludes `pubspec.lock` from published package archives, so this was never part of the 0.1.7 release artifact.