### PR TITLE
fix(web): fix method name mismatch for setSegments on Web

### DIFF
--- a/lib/dotlottie_flutter_web_impl.dart
+++ b/lib/dotlottie_flutter_web_impl.dart
@@ -181,6 +181,7 @@ class DotLottieWebView {
         return setProgress(progress);
 
       case 'setSegment':
+      case 'setSegments':
         final args = call.arguments as Map;
         final start = args['start'] as double;
         final end = args['end'] as double;


### PR DESCRIPTION
### Problem
Calling `setSegments()` on the Dart side fails on the Web platform because the Web switch-case only listens for `'setSegment'`.

### Solution
Added `case 'setSegments':` alongside `case 'setSegment':` in the Web message handler to ensure Web matches the current Dart API.