### PR TITLE
fix(web): parse slots JSON string to JSObject for setSlots API

### DIFF
--- a/lib/dotlottie_flutter_web_impl.dart
+++ b/lib/dotlottie_flutter_web_impl.dart
@@ -1,4 +1,5 @@
 // ignore: avoid_web_libraries_in_flutter
+import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:ui_web' as ui_web;
 
@@ -1251,7 +1252,9 @@ class DotLottieWebView {
         final player = dotLottiePlayer as JSObject;
         final method = player['setSlots'.toJS] as JSFunction?;
         if (method != null) {
-          method.callAsFunction(player, slots.toJS);
+          Map<String, dynamic> slotsMap = jsonDecode(slots);
+          JSObject slotsJsObj = slotsMap.jsify() as JSObject;
+          method.callAsFunction(player, slotsJsObj);
           return true;
         }
       } catch (e) {


### PR DESCRIPTION
## Problem
The Web platform implementation passes the `slots` parameter as a raw JSON `String` directly to the underlying JS function `setSlots`. However, the JS API signature expects an object (`setSlots(slots: Record<string, unknown>): void`), which causes the slots to not be applied correctly on Web.

## Solution
Parsed the `slots` JSON string and converted it to a `JSObject` before passing it to the JS `setSlots` function.